### PR TITLE
Added google spreadsheet importer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+token.pickle
+google.api.credential.json

--- a/COVID19ETL.py
+++ b/COVID19ETL.py
@@ -33,6 +33,7 @@ git_dir		   = "/home/foster/Documents/Library/Data/COVID-19/JHU/"
 daily_reports	   = "/csse_covid_19_data/csse_covid_19_daily_reports/"
 outputdir	   = "/home/foster/Documents/Library/Data/COVID-19/dtiproducts/"
 coordfile	   = "/home/foster/Documents/Library/Data/EARTH/country_coordinates.csv"
+fipsfile           = pd.read_csv("/home/hayashis/data/fips.csv")
 matchingColumnName = "Country/Region"
 sumColumnNames     = ["Confirmed", "Deaths", "Recovered"]
 carryoverColumns   = ["DataSource", "Last Update"]

--- a/ETL_funcs.py
+++ b/ETL_funcs.py
@@ -95,4 +95,4 @@ def addCoordinates(dataFrame, dataMatchColumn, coorFrame, coorMatchColumn):
     print("ERROR: addCoordinates columnName not found in provided coordinates Frame, or dataframe corrupt")
     return dataFrame
 
-  # 
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # OpenDataStoreETL
+
+## Importer
+
+### Dependencies
+
+```
+pip3 install --user --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+
+```
+### google.api.credential.json
+
+Install from https://developers.google.com/sheets/api/quickstart/python
+

--- a/google_importer.py
+++ b/google_importer.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import pickle
+import os.path
+import pandas as pd
+
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+
+# If modifying these scopes, delete the file token.pickle.
+GOOGLE_API_SCOPES = ['https://www.googleapis.com/auth/spreadsheets.readonly']
+
+#create here > https://developers.google.com/sheets/api/quickstart/go
+GOOGLE_API_CREDENTIAL = 'google.api.credential.json'
+
+def download_spreadsheet(spreadsheetID, rangeName):
+
+  creds = None
+  # The file token.pickle stores the user's access and refresh tokens, and is
+  # created automatically when the authorization flow completes for the first
+  # time.
+  if os.path.exists('token.pickle'):
+      with open('token.pickle', 'rb') as token:
+          creds = pickle.load(token)
+
+  # If there are no (valid) credentials available, let the user log in.
+  if not creds or not creds.valid:
+    if creds and creds.expired and creds.refresh_token:
+      creds.refresh(Request())
+    else:
+      flow = InstalledAppFlow.from_client_secrets_file(GOOGLE_API_CREDENTIAL, GOOGLE_API_SCOPES)
+      creds = flow.run_local_server(port=0)
+    # Save the credentials for the next run
+    with open('token.pickle', 'wb') as token:
+      pickle.dump(creds, token)
+
+  service = build('sheets', 'v4', credentials=creds)
+
+  sheet = service.spreadsheets()
+  result = sheet.values().get(spreadsheetId=spreadsheetID, range=rangeName).execute()
+  values = result.get('values', [])
+
+  if not values:
+    return None
+
+  header = values.pop(0)
+  return pd.DataFrame(values, columns=header)
+

--- a/import.py
+++ b/import.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import google_importer
+
+#https://docs.google.com/spreadsheets/d/1ns7jz1dRPXuCqISLZTPG1b6eYC-ds_PuQXLAFkr4UVk/edit?usp=sharing
+#TAB1
+frame = google_importer.download_spreadsheet(spreadsheetID='1ns7jz1dRPXuCqISLZTPG1b6eYC-ds_PuQXLAFkr4UVk', rangeName='TAB1!A2:E')
+frame.to_csv('/tmp/sample.tab1.csv', index=False)
+
+#TODO - ship each records to kafka?
+print(frame)
+
+#TAB2
+frame = google_importer.download_spreadsheet(spreadsheetID='1ns7jz1dRPXuCqISLZTPG1b6eYC-ds_PuQXLAFkr4UVk', rangeName='TAB2!A2:E')
+frame.to_csv('/tmp/sample.tab2.csv', index=False)
+
+#TODO - ship each records to kafka?
+print(frame)


### PR DESCRIPTION
This code imports Google spreadsheets and save it to .csv (or ship it to Kafka, etc..)

```
$ ./import.py 
     statefips countyfips stabb           state      county
0            1          1    AL         Alabama     Autauga
1            1          3    AL         Alabama     Baldwin
2            1          5    AL         Alabama     Barbour
3            1          7    AL         Alabama        Bibb
4            1          9    AL         Alabama      Blount
...        ...        ...   ...             ...         ...
3227        72        151    PR     Puerto Rico     Yabucoa
3228        72        153    PR     Puerto Rico       Yauco
3229        78         10    VI  Virgin Islands   St. Croix
3230        78         20    VI  Virgin Islands    St. John
3231        78         30    VI  Virgin Islands  St. Thomas

[3232 rows x 5 columns]
   2020-03-03  IN     Monrow  event1 12
0  2020-03-05  IN      Brown  event1  3
1  2020-03-06  IN  Washingon  event2  9

```

I've created a sample spreadsheet here 
> https://docs.google.com/spreadsheets/d/1ns7jz1dRPXuCqISLZTPG1b6eYC-ds_PuQXLAFkr4UVk/edit#gid=1932368744

pip dependencies are..
> pip3 install --user --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib

It requires Google API credential (google.api.credential.json) which can be generated and downloaded from 
> https://developers.google.com/sheets/api/quickstart/python

I am not sure how useful this is.. but it's a start.. An idea is to allow someone familiar with updating google spreadsheet to start feeding data to us - it could be emergency manager, someone from clinic, etc.. Most likely, they already have some information that they track on Google spreadsheet, and those can be easily mapped to OpenDataStoreETL services, I hope.


